### PR TITLE
chore: remove c2c banner

### DIFF
--- a/app/(app)/client-side.tsx
+++ b/app/(app)/client-side.tsx
@@ -18,6 +18,7 @@ import {
 import { POSTHOG_FEATURE_FLAGS } from "@/lib/posthog/shared";
 import { usePostHogFeatureFlagEnabled } from "@/lib/posthog/use-feature-flag-enabled";
 import C2CSakuraSignal from "@/app/components/c2c-sakura-signal";
+import { C2C_PROMO_ENABLED } from "@/lib/c2c-promo";
 
 const CommandPalette = dynamic(() => import("@/app/components/command-palette"), {
     ssr: false,
@@ -237,7 +238,7 @@ function ClientShell({
                     />
                 ) : null}
                 <main className="ec-app-main min-w-0 flex-1 pb-[calc(4.25rem+env(safe-area-inset-bottom))] pt-[env(safe-area-inset-top)] lg:pb-0 lg:pl-14 lg:pt-0">
-                    <C2CSakuraSignal />
+                    {C2C_PROMO_ENABLED ? <C2CSakuraSignal /> : null}
                     <PaperSplitViewProvider>
                         <Suspense fallback={null}>
                             <MobileStaticLogo />

--- a/app/components/mobile-tab-bar.tsx
+++ b/app/components/mobile-tab-bar.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { addTransitionType, startTransition, useEffect, useReducer, type MouseEvent } from "react";
 import { APP_NAV_LINKS } from "@/lib/app-nav-links";
 import c2cStyles from "./mobile-tab-bar.module.css";
+import { C2C_PROMO_ENABLED } from "@/lib/c2c-promo";
 
 const C2C_EVENT_URL =
   "https://gravitas.vit.ac.in/events/0eba5a6f-2687-416c-acd7-c51419433366";
@@ -269,41 +270,43 @@ export default function MobileTabBar({ toolsSheetOpen = false }: Props) {
             </li>
           );
         })}
-        <li className="relative z-[1] min-w-0 flex-1">
-          <a
-            href={C2C_EVENT_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Open Code2Create 7.0 event details"
-            className={`flex flex-col items-center rounded-xl font-semibold leading-tight tracking-tight ${
-              nativeAndroid
-                ? "gap-1 px-1 py-1 text-[11px] text-slate-500 transition-colors dark:text-slate-400"
-                : "gap-0.5 px-0.5 py-1.5 text-[11px] text-black/55 transition-[color,transform] active:scale-[0.98] dark:text-[#D5D5D5]/55 sm:text-[12px]"
-            }`}
-          >
-            <span
-              data-variant={nativeAndroid ? "android" : "web"}
-              className={`relative z-[1] flex items-center justify-center ${
+        {C2C_PROMO_ENABLED ? (
+          <li className="relative z-[1] min-w-0 flex-1">
+            <a
+              href={C2C_EVENT_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open Code2Create 7.0 event details"
+              className={`flex flex-col items-center rounded-xl font-semibold leading-tight tracking-tight ${
                 nativeAndroid
-                  ? "h-8 min-w-[3.5rem] rounded-full px-3"
-                  : "h-10 w-10 rounded-xl"
+                  ? "gap-1 px-1 py-1 text-[11px] text-slate-500 transition-colors dark:text-slate-400"
+                  : "gap-0.5 px-0.5 py-1.5 text-[11px] text-black/55 transition-[color,transform] active:scale-[0.98] dark:text-[#D5D5D5]/55 sm:text-[12px]"
               }`}
             >
-              <span className={c2cStyles.c2cLogoOrbit} aria-hidden="true">
-                <Image
-                  src="/icons/c2clogo.png"
-                  alt=""
-                  width={24}
-                  height={25}
-                  className={`${c2cStyles.c2cLogoImage} h-6 w-6 shrink-0 object-contain`}
-                />
+              <span
+                data-variant={nativeAndroid ? "android" : "web"}
+                className={`relative z-[1] flex items-center justify-center ${
+                  nativeAndroid
+                    ? "h-8 min-w-[3.5rem] rounded-full px-3"
+                    : "h-10 w-10 rounded-xl"
+                }`}
+              >
+                <span className={c2cStyles.c2cLogoOrbit} aria-hidden="true">
+                  <Image
+                    src="/icons/c2clogo.png"
+                    alt=""
+                    width={24}
+                    height={25}
+                    className={`${c2cStyles.c2cLogoImage} h-6 w-6 shrink-0 object-contain`}
+                  />
+                </span>
               </span>
-            </span>
-            <span className={`max-w-full truncate ${nativeAndroid ? "text-[12px]" : ""}`}>
-              C2C
-            </span>
-          </a>
-        </li>
+              <span className={`max-w-full truncate ${nativeAndroid ? "text-[12px]" : ""}`}>
+                C2C
+              </span>
+            </a>
+          </li>
+        ) : null}
       </ul>
     </nav>
   );

--- a/lib/c2c-promo.ts
+++ b/lib/c2c-promo.ts
@@ -8,4 +8,4 @@
  * this flipped back to 1, plus a refresh of the event URL and the "7.0"
  * labels/logo inside those two files.
  */
-export const C2C_PROMO_ENABLED: number = 1;
+export const C2C_PROMO_ENABLED: number = 0;

--- a/lib/c2c-promo.ts
+++ b/lib/c2c-promo.ts
@@ -1,0 +1,11 @@
+/**
+ * Kill switch for the Code2Create promo surfaces.
+ *
+ * 1 = enabled, 0 = disabled. While this is 0 nothing C2C-related renders:
+ * not the desktop sakura banner/dock (`app/components/c2c-sakura-signal.tsx`)
+ * and not the mobile tab bar entry (`app/components/mobile-tab-bar.tsx`).
+ * The components themselves are left intact so next year's edition only needs
+ * this flipped back to 1, plus a refresh of the event URL and the "7.0"
+ * labels/logo inside those two files.
+ */
+export const C2C_PROMO_ENABLED: number = 1;


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

## Summary
- Disables the Code2Create promotional surfaces through a shared switch in the app shell and mobile navigation.
- The mobile bar continues to show and align its four standard destinations after the promotional entry is removed.
- Repeated PDF and ZIP filename suffixes are normalized while existing TypeScript consumers remain compatible.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the intended promotional UI is removed cleanly, normal navigation remains intact, and download filename normalization behaves correctly.

No actionable issues were found. Focused rendered UI checks confirmed the disabled promotion state and retained mobile layout; focused filename checks passed across repeated and mixed-case suffixes.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Checked the shared switch and UI consumers to confirm the disabled value guards the Sakura signal and the C2C mobile tab.
- Performed a before-and-after mobile rendering comparison showing the enabled state with Sakura and five tabs, then the disabled state without promotional surfaces and with four standard tabs in the same 390x76 navigation bounds.
- Validated that the updated filename handling passes seven assertions for repeated and mixed-case PDF and ZIP suffixes, and that a representative TypeScript consumer importing the affected helpers compiled successfully.
- Recorded that the real-app blocker is due to DATABASE\_URL not being set, and noted that static validation passed with the render validation summary confirming the mobile navigation changes.
- Reproduced the prior filename-normalization defect and confirmed that the after-run checks pass all seven runtime assertions, with the TypeScript consumer compiling and the harness/config authored.

<a href="https://app.greptile.com/trex/runs/23811240/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/examcooker/commit/5767bbaec462017f75b31bf0a4bfc81362a59ee3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63056320)</sub>

<!-- /greptile_comment -->